### PR TITLE
Add Message Search API

### DIFF
--- a/controllers/messageController.go
+++ b/controllers/messageController.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"onez19/models"
 	"onez19/services"
+	"regexp"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -56,6 +57,40 @@ func GetAllMessagesByWorkspaceID(c *fiber.Ctx) error {
 	messages, err := services.GetAllMessagesByWorkspaceID(workspaceID)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to fetch message"})
+	}
+
+	return c.JSON(messages)
+}
+
+func SearchMessages(c *fiber.Ctx) error {
+	query := c.Query("query")
+	regex := c.Query("regex")
+
+	if query == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Query parameter cannot be empty",
+		})
+	}
+
+	var messages []models.Message
+	var err error
+
+	if regex == "true" {
+		_, err = regexp.Compile(query)
+		if err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": "Invalid regular expression",
+			})
+		}
+		messages, err = services.SearchMessagesByRegex(query)
+	} else {
+		messages, err = services.SearchMessagesByText(query)
+	}
+
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": err.Error(),
+		})
 	}
 
 	return c.JSON(messages)

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -34,4 +34,5 @@ func SetupRoutes(app *fiber.App) {
 	app.Post("/messages", controllers.CreateMessage)
 	app.Post("/message/delete", controllers.DeleteMessage)
 	app.Get("/messages/:workspaceId", controllers.GetAllMessagesByWorkspaceID)
+	app.Get("/messages/search", controllers.SearchMessages)
 }

--- a/services/messageService.go
+++ b/services/messageService.go
@@ -72,3 +72,41 @@ func GetAllMessagesByWorkspaceID(workspace_id string) ([]models.Message, error) 
 	return messages, nil
 
 }
+
+func SearchMessagesByText(query string) ([]models.Message, error) {
+	rows, err := config.DB.Query("SELECT * FROM message WHERE message LIKE ? ORDER BY date DESC", "%"+query+"%")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var messages []models.Message
+	for rows.Next() {
+		var message models.Message
+		if err := rows.Scan(&message.ID, &message.Message, &message.Date, &message.WorkspaceID, &message.Username); err != nil {
+			return nil, err
+		}
+		messages = append(messages, message)
+	}
+
+	return messages, nil
+}
+
+func SearchMessagesByRegex(query string) ([]models.Message, error) {
+	rows, err := config.DB.Query("SELECT * FROM message WHERE message REGEXP ? ORDER BY date DESC", query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var messages []models.Message
+	for rows.Next() {
+		var message models.Message
+		if err := rows.Scan(&message.ID, &message.Message, &message.Date, &message.WorkspaceID, &message.Username); err != nil {
+			return nil, err
+		}
+		messages = append(messages, message)
+	}
+
+	return messages, nil
+}


### PR DESCRIPTION
This pull request introduces a new feature to the project: a message search API using the Fiber framework. The API allows clients to search messages in the database by normal text or regular expression, ensuring that the latest messages are shown first if multiple matches are found.

**Changes:**

1. API Endpoint:
- Added /message/search endpoint to search messages.
- Supports two query parameters:
- - query: The search term (required).
- - regex: Indicates whether to use regular expression search (optional, defaults to false).

2. Validation:
- Ensures the query parameter is not empty.
- Validates the regular expression if regex=true.

**Examples:**
- Search by normal text: GET /message/search?query=hello
- Search by regular expression: GET /message/search?query=^hello&regex=true
- Invalid regular expression: GET /message/search?query=[hello&regex=true
- Empty query parameter: GET /message/search?query=
<hr>
Please review the changes and let me know if there are any questions or further adjustments needed. Thank you!